### PR TITLE
Add Kaggle notebook for LightGCN

### DIFF
--- a/LightGCN_Kaggle.ipynb
+++ b/LightGCN_Kaggle.ipynb
@@ -1,0 +1,120 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# LightGCN on Kaggle\n",
+        "\n",
+        "This notebook demonstrates how to set up and run the LightGCN model on Kaggle."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Environment Setup\n",
+        "\n",
+        "First, we need to set up the environment by installing the required libraries and specifying their versions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!pip install tensorflow==1.11.0\n",
+        "!pip install numpy==1.14.3\n",
+        "!pip install scipy==1.1.0\n",
+        "!pip install scikit-learn==0.19.1\n",
+        "!pip install cython==0.29.15"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Compile C++ Evaluator\n",
+        "\n",
+        "Next, we need to compile the C++ evaluator by running the following command in the root directory of the repository."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!python setup.py build_ext --inplace"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Upload Dataset Files\n",
+        "\n",
+        "Upload the dataset files to the appropriate directories in Kaggle. For example, place the `train.txt`, `test.txt`, `user_list.txt`, and `item_list.txt` files in the `Data/amazon-book` directory."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Update Data Path\n",
+        "\n",
+        "Update the `data_path` argument in the `utility/parser.py` file to match the Kaggle environment."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "os.environ['data_path'] = '/kaggle/input/your-dataset-directory/'"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Run LightGCN Model\n",
+        "\n",
+        "Finally, run the `LightGCN.py` script with the desired arguments to start training the model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!python LightGCN.py --dataset amazon-book --regs [1e-4] --embed_size 64 --layer_size [64,64,64] --lr 0.001 --batch_size 8192 --epoch 1000"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/README.md
+++ b/README.md
@@ -109,4 +109,9 @@ We provide three processed datasets: Gowalla, Yelp2018 and Amazon-book.
   * Parallelized sampling on CPU
   * C++ evaluation for top-k recommendation
 
-=======
+## Running LightGCN on Kaggle
+To run the LightGCN model on Kaggle, follow these steps:
+
+1. Open the `LightGCN_Kaggle.ipynb` notebook in Kaggle.
+2. Follow the instructions in the notebook to set up the environment, install required libraries, and upload dataset files.
+3. Run the notebook cells to compile the C++ evaluator, update the data path, and train the LightGCN model.


### PR DESCRIPTION
Add a Jupyter notebook for running LightGCN on Kaggle.

* **LightGCN_Kaggle.ipynb**
  - Create a notebook for setting up the environment, installing required libraries, and running the LightGCN model on Kaggle.
  - Include steps for compiling the C++ evaluator and uploading dataset files.
  - Update the `data_path` argument to match the Kaggle environment.
  - Provide instructions for running the LightGCN model with desired arguments.

* **README.md**
  - Add instructions for running the `LightGCN_Kaggle.ipynb` notebook on Kaggle.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Faithgel/LightGCN?shareId=XXXX-XXXX-XXXX-XXXX).