### PR TITLE
Add Python version and virtual environment setup

### DIFF
--- a/LightGCN_Kaggle.ipynb
+++ b/LightGCN_Kaggle.ipynb
@@ -35,6 +35,43 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "## Specify Python Version\n",
+        "\n",
+        "We need to specify the Python version as 3.6.5, which is required for this project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!python --version"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Create Virtual Environment\n",
+        "\n",
+        "Create a virtual environment with Python 3.6.5."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!python3.6 -m venv lightgcn_env\n",
+        "!source lightgcn_env/bin/activate"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## Compile C++ Evaluator\n",
         "\n",
         "Next, we need to compile the C++ evaluator by running the following command in the root directory of the repository."

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ The code has been tested running under Python 3.6.5. The required packages are a
 * scipy == 1.1.0
 * sklearn == 0.19.1
 * cython == 0.29.15
+
+## Creating a Virtual Environment
+To create a virtual environment with Python 3.6.5, run the following commands:
+```
+python3.6 -m venv lightgcn_env
+source lightgcn_env/bin/activate
+```
+
 ## C++ evaluator
 We have implemented C++ code to output metrics during and after training, which is much more efficient than python evaluator. It needs to be compiled first using the following command. 
 ```


### PR DESCRIPTION
Add Python version specification and virtual environment creation command to the notebook and README.

* **Notebook (`LightGCN_Kaggle.ipynb`):**
  - Add a markdown cell specifying Python 3.6.5 as the required version.
  - Add a code cell to check the Python version.
  - Add a markdown cell with instructions to create a virtual environment.
  - Add a code cell to create and activate a virtual environment with Python 3.6.5.

* **README (`README.md`):**
  - Add a section with instructions to create a virtual environment with Python 3.6.5.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Faithgel/LightGCN/pull/2?shareId=b94880d7-4124-436a-84dc-2fa721f44acb).